### PR TITLE
:sparkles: New front page & library list

### DIFF
--- a/.github/scripts/generate_index.py
+++ b/.github/scripts/generate_index.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 - 2025 Khalil Estell and the libhal contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+libhal API Index Data Generator
+
+Scans the api repository directory for library subdirectories and their
+versions, then outputs a libraries.json file. This file is consumed by
+the index.html front page to render the library directory.
+
+Usage:
+    python3 generate_index.py /path/to/api/repo
+    python3 generate_index.py /path/to/api/repo --output /path/to/libraries.json
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SKIP_DIRS = {".git", ".github"}
+
+
+def discover_libraries(repo_dir: Path) -> list[dict]:
+    """
+    Scan the repo directory for library subdirectories and read their
+    switcher.json to determine available versions.
+
+    Returns a sorted list of dicts with keys: name, versions, latest_url
+    """
+    libraries = []
+
+    for entry in sorted(repo_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        if entry.name in SKIP_DIRS or entry.name.startswith("."):
+            continue
+
+        switcher_path = entry / "switcher.json"
+        switcher_versions = []
+        if switcher_path.exists():
+            try:
+                with open(switcher_path) as f:
+                    switcher_versions = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        # Determine version subdirectories
+        version_dirs = sorted(
+            [d.name for d in entry.iterdir()
+             if d.is_dir() and d.name != ".git"],
+        )
+
+        if not version_dirs:
+            continue
+
+        # Build version list with URLs
+        versions = []
+        for v in version_dirs:
+            match = next(
+                (sv for sv in switcher_versions if sv["version"] == v),
+                None,
+            )
+            url = match["url"] if match else f"{entry.name}/{v}"
+            versions.append({"version": v, "url": url})
+
+        # Latest is the last entry (highest semver or last branch)
+        latest_url = versions[-1]["url"]
+
+        libraries.append({
+            "name": entry.name,
+            "versions": versions,
+            "latest_url": latest_url,
+        })
+
+    return libraries
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate libraries.json for the libhal API docs site")
+    parser.add_argument(
+        "repo_dir",
+        help="Path to the root of the api repository")
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output file path (default: <repo_dir>/libraries.json)")
+
+    args = parser.parse_args()
+
+    repo_dir = Path(args.repo_dir)
+    if not repo_dir.is_dir():
+        print(f"Error: {repo_dir} is not a directory")
+        return 1
+
+    libraries = discover_libraries(repo_dir)
+
+    if not libraries:
+        print("Warning: No library directories found")
+
+    output_path = (
+        Path(args.output) if args.output else repo_dir / "libraries.json"
+    )
+    with open(output_path, "w") as f:
+        json.dump(libraries, f, indent=2)
+
+    print(f"Generated {output_path} with {len(libraries)} libraries")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/index.html
+++ b/index.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>libhal API Documentation</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                   "Helvetica Neue", Arial, sans-serif;
+      background: #f5f7fa;
+      color: #1a1a2e;
+      line-height: 1.6;
+      padding: 2rem 1rem;
+    }
+    header {
+      text-align: center;
+      margin-bottom: 2.5rem;
+    }
+    header h1 {
+      font-size: 2rem;
+      font-weight: 700;
+      margin-bottom: 0.25rem;
+    }
+    header p {
+      color: #555;
+      font-size: 1.05rem;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: 1.25rem;
+      max-width: 960px;
+      margin: 0 auto;
+    }
+    .card {
+      background: #fff;
+      border: 1px solid #e0e4ea;
+      border-radius: 8px;
+      padding: 1.25rem 1.5rem;
+    }
+    .card h2 {
+      font-size: 1.15rem;
+      margin-bottom: 0.75rem;
+    }
+    .card h2 a {
+      color: #1a1a2e;
+      text-decoration: none;
+    }
+    .card h2 a:hover {
+      color: #3a6df0;
+    }
+    .versions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.4rem;
+    }
+    a.version {
+      display: inline-block;
+      padding: 0.2rem 0.6rem;
+      background: #eef1f6;
+      border-radius: 4px;
+      font-size: 0.85rem;
+      color: #3a6df0;
+      text-decoration: none;
+    }
+    a.version:hover {
+      background: #3a6df0;
+      color: #fff;
+    }
+    #error {
+      text-align: center;
+      color: #c0392b;
+      margin-top: 2rem;
+      display: none;
+    }
+    footer {
+      text-align: center;
+      margin-top: 3rem;
+      font-size: 0.85rem;
+      color: #888;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>libhal API Documentation</h1>
+    <p>Browse API references for all libhal libraries</p>
+  </header>
+  <div class="grid" id="grid"></div>
+  <p id="error">Could not load library data.</p>
+  <footer>
+    Auto-generated from repository contents
+  </footer>
+
+  <script>
+    fetch("libraries.json")
+      .then(function (res) {
+        if (!res.ok) throw new Error(res.statusText);
+        return res.json();
+      })
+      .then(function (libraries) {
+        var grid = document.getElementById("grid");
+        libraries.forEach(function (lib) {
+          var card = document.createElement("div");
+          card.className = "card";
+
+          var heading = document.createElement("h2");
+          var link = document.createElement("a");
+          link.href = lib.latest_url;
+          link.textContent = lib.name;
+          heading.appendChild(link);
+          card.appendChild(heading);
+
+          var versions = document.createElement("div");
+          versions.className = "versions";
+          lib.versions.forEach(function (v) {
+            var a = document.createElement("a");
+            a.className = "version";
+            a.href = v.url;
+            a.textContent = v.version;
+            versions.appendChild(a);
+          });
+          card.appendChild(versions);
+
+          grid.appendChild(card);
+        });
+      })
+      .catch(function () {
+        document.getElementById("error").style.display = "block";
+      });
+  </script>
+</body>
+</html>

--- a/libraries.json
+++ b/libraries.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "libhal",
+    "versions": [
+      {
+        "version": "4.10.0",
+        "url": "https://libhal.github.io/api/libhal/4.10.0"
+      },
+      {
+        "version": "main",
+        "url": "https://libhal.github.io/api/libhal/main"
+      }
+    ],
+    "latest_url": "https://libhal.github.io/api/libhal/main"
+  },
+  {
+    "name": "libhal-arm-mcu",
+    "versions": [
+      {
+        "version": "1.10.0",
+        "url": "https://libhal.github.io/api/libhal-arm-mcu/1.10.0"
+      },
+      {
+        "version": "1.12.0",
+        "url": "https://libhal.github.io/api/libhal-arm-mcu/1.12.0"
+      },
+      {
+        "version": "1.9.0",
+        "url": "https://libhal.github.io/api/libhal-arm-mcu/1.9.0"
+      },
+      {
+        "version": "main",
+        "url": "https://libhal.github.io/api/libhal-arm-mcu/main"
+      }
+    ],
+    "latest_url": "https://libhal.github.io/api/libhal-arm-mcu/main"
+  },
+  {
+    "name": "libhal-util",
+    "versions": [
+      {
+        "version": "5.4.3",
+        "url": "https://libhal.github.io/api/libhal-util/5.4.3"
+      },
+      {
+        "version": "main",
+        "url": "https://libhal.github.io/api/libhal-util/main"
+      }
+    ],
+    "latest_url": "https://libhal.github.io/api/libhal-util/main"
+  },
+  {
+    "name": "strong_ptr",
+    "versions": [
+      {
+        "version": "main",
+        "url": "https://libhal.github.io/api/strong_ptr/main"
+      }
+    ],
+    "latest_url": "https://libhal.github.io/api/strong_ptr/main"
+  }
+]


### PR DESCRIPTION
New python script `generate_index.py` analyzes the directory and generates a `libraries.json` file with each library and its versions. This allows the front page to provide a list of APIs for everything currently within the API repo.

Next step would be to automate this process so each time the main branch gets updated, the `libraries.json` file is also updated.